### PR TITLE
fix: make tuples flexible in string transformers

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -14,14 +14,14 @@ files = [
 
 [[package]]
 name = "astroid"
-version = "2.13.3"
+version = "2.13.5"
 description = "An abstract syntax tree for Python with inference support."
 category = "dev"
 optional = false
 python-versions = ">=3.7.2"
 files = [
-    {file = "astroid-2.13.3-py3-none-any.whl", hash = "sha256:14c1603c41cc61aae731cad1884a073c4645e26f126d13ac8346113c95577f3b"},
-    {file = "astroid-2.13.3.tar.gz", hash = "sha256:6afc22718a48a689ca24a97981ad377ba7fb78c133f40335dfd16772f29bcfb1"},
+    {file = "astroid-2.13.5-py3-none-any.whl", hash = "sha256:6891f444625b6edb2ac798829b689e95297e100ddf89dbed5a8c610e34901501"},
+    {file = "astroid-2.13.5.tar.gz", hash = "sha256:df164d5ac811b9f44105a72b8f9d5edfb7b5b2d7e979b04ea377a77b3229114a"},
 ]
 
 [package.dependencies]
@@ -1074,14 +1074,14 @@ async = ["aiofiles (>=0.7,<1.0)"]
 
 [[package]]
 name = "identify"
-version = "2.5.16"
+version = "2.5.17"
 description = "File identification library for Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "identify-2.5.16-py2.py3-none-any.whl", hash = "sha256:832832a58ecc1b8f33d5e8cb4f7d3db2f5c7fbe922dfee5f958b48fed691501a"},
-    {file = "identify-2.5.16.tar.gz", hash = "sha256:c47acedfe6495b1c603ed7e93469b26e839cab38db4155113f36f718f8b3dc47"},
+    {file = "identify-2.5.17-py2.py3-none-any.whl", hash = "sha256:7d526dd1283555aafcc91539acc061d8f6f59adb0a7bba462735b0a318bff7ed"},
+    {file = "identify-2.5.17.tar.gz", hash = "sha256:93cc61a861052de9d4c541a7acb7e3dcc9c11b398a2144f6e52ae5285f5f4f06"},
 ]
 
 [package.extras]
@@ -1347,14 +1347,14 @@ format-nongpl = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-
 
 [[package]]
 name = "jupyter-client"
-version = "8.0.1"
+version = "8.0.2"
 description = "Jupyter protocol implementation and client libraries"
 category = "main"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "jupyter_client-8.0.1-py3-none-any.whl", hash = "sha256:6016b874fd1111d721bc5bee30624399e876e79e6f395d1a559e6dce9fb2e1ba"},
-    {file = "jupyter_client-8.0.1.tar.gz", hash = "sha256:3f67b1c8b7687e6db09bef10ff97669932b5e6ef6f5a8ee56d444b89022c5007"},
+    {file = "jupyter_client-8.0.2-py3-none-any.whl", hash = "sha256:c53731eb590b68839b0ce04bf46ff8c4f03278f5d9fe5c3b0f268a57cc2bd97e"},
+    {file = "jupyter_client-8.0.2.tar.gz", hash = "sha256:47ac9f586dbcff4d79387ec264faf0fdeb5f14845fa7345fd7d1e378f8096011"},
 ]
 
 [package.dependencies]
@@ -1371,14 +1371,14 @@ test = ["codecov", "coverage", "ipykernel (>=6.14)", "mypy", "paramiko", "pre-co
 
 [[package]]
 name = "jupyter-core"
-version = "5.1.5"
+version = "5.2.0"
 description = "Jupyter core package. A base package on which Jupyter projects rely."
 category = "main"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "jupyter_core-5.1.5-py3-none-any.whl", hash = "sha256:83064d61bb2a9bc874e8184331c117b3778c2a7e1851f60cb00d273ceb3285ae"},
-    {file = "jupyter_core-5.1.5.tar.gz", hash = "sha256:8e54c48cde1e0c8345f64bcf9658b78044ddf02b273726cea9d9f59be4b02130"},
+    {file = "jupyter_core-5.2.0-py3-none-any.whl", hash = "sha256:4bdc2928c37f6917130c667d8b8708f20aee539d8283c6be72aabd2a4b4c83b0"},
+    {file = "jupyter_core-5.2.0.tar.gz", hash = "sha256:1407cdb4c79ee467696c04b76633fc1884015fa109323365a6372c8e890cc83f"},
 ]
 
 [package.dependencies]
@@ -2239,14 +2239,14 @@ ptyprocess = ">=0.5"
 
 [[package]]
 name = "phonenumbers"
-version = "8.13.4"
+version = "8.13.5"
 description = "Python version of Google's common library for parsing, formatting, storing and validating international phone numbers."
 category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {file = "phonenumbers-8.13.4-py2.py3-none-any.whl", hash = "sha256:a577a46c069ad889c7b7cf4dd978751d059edeab28b97acead4775d2ea1fc70a"},
-    {file = "phonenumbers-8.13.4.tar.gz", hash = "sha256:6d63455012fc9431105ffc7739befca61c3efc551b287dca58d2be2e745475a9"},
+    {file = "phonenumbers-8.13.5-py2.py3-none-any.whl", hash = "sha256:2e3fd1f3fde226b289489275517c76edf223eafd9f43a2c2c36498a44b73d4b0"},
+    {file = "phonenumbers-8.13.5.tar.gz", hash = "sha256:6eb2faf29c19f946baf10f1c977a1f856cab90819fe7735b8e141d5407420c4a"},
 ]
 
 [[package]]
@@ -2384,14 +2384,14 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pre-commit"
-version = "3.0.1"
+version = "3.0.2"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
 category = "dev"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pre_commit-3.0.1-py2.py3-none-any.whl", hash = "sha256:61ecb75e0e99939cc30c79181c0394545657855e9172c42ff98ebecb0e02fcb7"},
-    {file = "pre_commit-3.0.1.tar.gz", hash = "sha256:3a3f9229e8c19a626a7f91be25b3c8c135e52de1a678da98eb015c0d0baea7a5"},
+    {file = "pre_commit-3.0.2-py2.py3-none-any.whl", hash = "sha256:f448d5224c70e196a6c6f87961d2333dfdc49988ebbf660477f9efe991c03597"},
+    {file = "pre_commit-3.0.2.tar.gz", hash = "sha256:aa97fa71e7ab48225538e1e91a6b26e483029e6de64824f04760c32557bc91d7"},
 ]
 
 [package.dependencies]
@@ -3908,14 +3908,14 @@ opt-einsum = ["opt-einsum (>=3.3)"]
 
 [[package]]
 name = "torchmetrics"
-version = "0.11.0"
+version = "0.11.1"
 description = "PyTorch native Metrics"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "torchmetrics-0.11.0-py3-none-any.whl", hash = "sha256:f809c3cb86a0bd3d8743df0888040257e20d371a937ff9114f582a60ce1a1c67"},
-    {file = "torchmetrics-0.11.0.tar.gz", hash = "sha256:c838e0491d80775daadd0802e27ae3af112a52086c9ba8cbcd1e2807243c89ac"},
+    {file = "torchmetrics-0.11.1-py3-none-any.whl", hash = "sha256:9987d7c21b081cceef246a72be1ce25bf29c842764f59dda54f59e3b4cd1970b"},
+    {file = "torchmetrics-0.11.1.tar.gz", hash = "sha256:de2e9feb3316f798ab08b318302ff04e764f47e691f0847f780044279fa176ca"},
 ]
 
 [package.dependencies]
@@ -4018,14 +4018,14 @@ telegram = ["requests"]
 
 [[package]]
 name = "traitlets"
-version = "5.8.1"
+version = "5.9.0"
 description = "Traitlets Python configuration system"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "traitlets-5.8.1-py3-none-any.whl", hash = "sha256:a1ca5df6414f8b5760f7c5f256e326ee21b581742114545b462b35ffe3f04861"},
-    {file = "traitlets-5.8.1.tar.gz", hash = "sha256:32500888f5ff7bbf3b9267ea31748fa657aaf34d56d85e60f91dda7dc7f5785b"},
+    {file = "traitlets-5.9.0-py3-none-any.whl", hash = "sha256:9e6ec080259b9a5940c797d58b613b5e31441c2257b87c2e795c5228ae80d2d8"},
+    {file = "traitlets-5.9.0.tar.gz", hash = "sha256:f6cde21a9c68cf756af02035f72d5a723bf607e862e7be33ece505abf4a3bad9"},
 ]
 
 [package.extras]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 appnope==0.1.3 ; python_version >= "3.8" and python_version < "3.11" and platform_system == "Darwin" or python_version >= "3.8" and python_version < "3.11" and sys_platform == "darwin" \
     --hash=sha256:02bd91c4de869fbb1e1c50aafc4098827a7a54ab2f39d9dcba6c9547ed920e24 \
     --hash=sha256:265a455292d0bd8a72453494fa24df5a11eb18373a60c7c0430889f22548605e
-astroid==2.13.3 ; python_version >= "3.8" and python_version < "3.11" \
-    --hash=sha256:14c1603c41cc61aae731cad1884a073c4645e26f126d13ac8346113c95577f3b \
-    --hash=sha256:6afc22718a48a689ca24a97981ad377ba7fb78c133f40335dfd16772f29bcfb1
+astroid==2.13.5 ; python_version >= "3.8" and python_version < "3.11" \
+    --hash=sha256:6891f444625b6edb2ac798829b689e95297e100ddf89dbed5a8c610e34901501 \
+    --hash=sha256:df164d5ac811b9f44105a72b8f9d5edfb7b5b2d7e979b04ea377a77b3229114a
 asttokens==2.2.1 ; python_version >= "3.8" and python_version < "3.11" \
     --hash=sha256:4622110b2a6f30b77e1473affaa97e711bc2f07d3f10848420ff1898edbe94f3 \
     --hash=sha256:6b0ac9e93fb0335014d382b8fa9b3afa7df546984258005da0b9e7095b3deb1c
@@ -439,9 +439,9 @@ gitdb==4.0.10 ; python_version >= "3.8" and python_version < "3.11" \
 gitpython==3.1.30 ; python_version >= "3.8" and python_version < "3.11" \
     --hash=sha256:769c2d83e13f5d938b7688479da374c4e3d49f71549aaf462b646db9602ea6f8 \
     --hash=sha256:cd455b0000615c60e286208ba540271af9fe531fa6a87cc590a7298785ab2882
-identify==2.5.16 ; python_version >= "3.8" and python_version < "3.11" \
-    --hash=sha256:832832a58ecc1b8f33d5e8cb4f7d3db2f5c7fbe922dfee5f958b48fed691501a \
-    --hash=sha256:c47acedfe6495b1c603ed7e93469b26e839cab38db4155113f36f718f8b3dc47
+identify==2.5.17 ; python_version >= "3.8" and python_version < "3.11" \
+    --hash=sha256:7d526dd1283555aafcc91539acc061d8f6f59adb0a7bba462735b0a318bff7ed \
+    --hash=sha256:93cc61a861052de9d4c541a7acb7e3dcc9c11b398a2144f6e52ae5285f5f4f06
 idna==3.4 ; python_version >= "3.8" and python_version < "3.11" \
     --hash=sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4 \
     --hash=sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2
@@ -477,12 +477,12 @@ joblib==1.2.0 ; python_version >= "3.8" and python_version < "3.11" \
 jsonschema==4.17.3 ; python_version >= "3.8" and python_version < "3.11" \
     --hash=sha256:0f864437ab8b6076ba6707453ef8f98a6a0d512a80e93f8abdb676f737ecb60d \
     --hash=sha256:a870ad254da1a8ca84b6a2905cac29d265f805acc57af304784962a2aa6508f6
-jupyter-client==8.0.1 ; python_version >= "3.8" and python_version < "3.11" \
-    --hash=sha256:3f67b1c8b7687e6db09bef10ff97669932b5e6ef6f5a8ee56d444b89022c5007 \
-    --hash=sha256:6016b874fd1111d721bc5bee30624399e876e79e6f395d1a559e6dce9fb2e1ba
-jupyter-core==5.1.5 ; python_version >= "3.8" and python_version < "3.11" \
-    --hash=sha256:83064d61bb2a9bc874e8184331c117b3778c2a7e1851f60cb00d273ceb3285ae \
-    --hash=sha256:8e54c48cde1e0c8345f64bcf9658b78044ddf02b273726cea9d9f59be4b02130
+jupyter-client==8.0.2 ; python_version >= "3.8" and python_version < "3.11" \
+    --hash=sha256:47ac9f586dbcff4d79387ec264faf0fdeb5f14845fa7345fd7d1e378f8096011 \
+    --hash=sha256:c53731eb590b68839b0ce04bf46ff8c4f03278f5d9fe5c3b0f268a57cc2bd97e
+jupyter-core==5.2.0 ; python_version >= "3.8" and python_version < "3.11" \
+    --hash=sha256:1407cdb4c79ee467696c04b76633fc1884015fa109323365a6372c8e890cc83f \
+    --hash=sha256:4bdc2928c37f6917130c667d8b8708f20aee539d8283c6be72aabd2a4b4c83b0
 jupyterlab-widgets==3.0.5 ; python_version >= "3.8" and python_version < "3.11" \
     --hash=sha256:a04a42e50231b355b7087e16a818f541e53589f7647144ea0344c4bf16f300e5 \
     --hash=sha256:eeaecdeaf6c03afc960ddae201ced88d5979b4ca9c3891bcb8f6631af705f5ef
@@ -771,9 +771,9 @@ pbr==5.11.1 ; python_version >= "3.8" and python_version < "3.11" \
 pexpect==4.8.0 ; python_version >= "3.8" and python_version < "3.11" and sys_platform != "win32" \
     --hash=sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937 \
     --hash=sha256:fc65a43959d153d0114afe13997d439c22823a27cefceb5ff35c2178c6784c0c
-phonenumbers==8.13.4 ; python_version >= "3.8" and python_version < "3.11" \
-    --hash=sha256:6d63455012fc9431105ffc7739befca61c3efc551b287dca58d2be2e745475a9 \
-    --hash=sha256:a577a46c069ad889c7b7cf4dd978751d059edeab28b97acead4775d2ea1fc70a
+phonenumbers==8.13.5 ; python_version >= "3.8" and python_version < "3.11" \
+    --hash=sha256:2e3fd1f3fde226b289489275517c76edf223eafd9f43a2c2c36498a44b73d4b0 \
+    --hash=sha256:6eb2faf29c19f946baf10f1c977a1f856cab90819fe7735b8e141d5407420c4a
 pickleshare==0.7.5 ; python_version >= "3.8" and python_version < "3.11" \
     --hash=sha256:87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca \
     --hash=sha256:9649af414d74d4df115d5d718f82acb59c9d418196b7b4290ed47a12ce62df56
@@ -847,9 +847,9 @@ pkgutil-resolve-name==1.3.10 ; python_version >= "3.8" and python_version < "3.9
 platformdirs==2.6.2 ; python_version >= "3.8" and python_version < "3.11" \
     --hash=sha256:83c8f6d04389165de7c9b6f0c682439697887bca0aa2f1c87ef1826be3584490 \
     --hash=sha256:e1fea1fe471b9ff8332e229df3cb7de4f53eeea4998d3b6bfff542115e998bd2
-pre-commit==3.0.1 ; python_version >= "3.8" and python_version < "3.11" \
-    --hash=sha256:3a3f9229e8c19a626a7f91be25b3c8c135e52de1a678da98eb015c0d0baea7a5 \
-    --hash=sha256:61ecb75e0e99939cc30c79181c0394545657855e9172c42ff98ebecb0e02fcb7
+pre-commit==3.0.2 ; python_version >= "3.8" and python_version < "3.11" \
+    --hash=sha256:aa97fa71e7ab48225538e1e91a6b26e483029e6de64824f04760c32557bc91d7 \
+    --hash=sha256:f448d5224c70e196a6c6f87961d2333dfdc49988ebbf660477f9efe991c03597
 preshed==3.0.8 ; python_version >= "3.8" and python_version < "3.11" \
     --hash=sha256:019d8fa4161035811fb2804d03214143298739e162d0ad24e087bd46c50970f5 \
     --hash=sha256:06793022a56782ef51d74f1399925a2ba958e50c5cfbc6fa5b25c4945e158a07 \
@@ -1380,9 +1380,9 @@ torch==1.13.1 ; python_version >= "3.8" and python_version < "3.11" \
     --hash=sha256:eeeb204d30fd40af6a2d80879b46a7efbe3cf43cdbeb8838dd4f3d126cc90b2b \
     --hash=sha256:f402ca80b66e9fbd661ed4287d7553f7f3899d9ab54bf5c67faada1555abde28 \
     --hash=sha256:fd12043868a34a8da7d490bf6db66991108b00ffbeecb034228bfcbbd4197143
-torchmetrics==0.11.0 ; python_version >= "3.8" and python_version < "3.11" \
-    --hash=sha256:c838e0491d80775daadd0802e27ae3af112a52086c9ba8cbcd1e2807243c89ac \
-    --hash=sha256:f809c3cb86a0bd3d8743df0888040257e20d371a937ff9114f582a60ce1a1c67
+torchmetrics==0.11.1 ; python_version >= "3.8" and python_version < "3.11" \
+    --hash=sha256:9987d7c21b081cceef246a72be1ce25bf29c842764f59dda54f59e3b4cd1970b \
+    --hash=sha256:de2e9feb3316f798ab08b318302ff04e764f47e691f0847f780044279fa176ca
 torchvision==0.14.1 ; python_version >= "3.8" and python_version < "3.11" \
     --hash=sha256:0ed02aefd09bf1114d35f1aa7dce55aa61c2c7e57f9aa02dce362860be654e85 \
     --hash=sha256:13986f0c15377ff23039e1401012ccb6ecf71024ce53def27139e4eac5a57592 \
@@ -1418,9 +1418,9 @@ tornado==6.2 ; python_version >= "3.8" and python_version < "3.11" \
 tqdm==4.64.1 ; python_version >= "3.8" and python_version < "3.11" \
     --hash=sha256:5f4f682a004951c1b450bc753c710e9280c5746ce6ffedee253ddbcbf54cf1e4 \
     --hash=sha256:6fee160d6ffcd1b1c68c65f14c829c22832bc401726335ce92c52d395944a6a1
-traitlets==5.8.1 ; python_version >= "3.8" and python_version < "3.11" \
-    --hash=sha256:32500888f5ff7bbf3b9267ea31748fa657aaf34d56d85e60f91dda7dc7f5785b \
-    --hash=sha256:a1ca5df6414f8b5760f7c5f256e326ee21b581742114545b462b35ffe3f04861
+traitlets==5.9.0 ; python_version >= "3.8" and python_version < "3.11" \
+    --hash=sha256:9e6ec080259b9a5940c797d58b613b5e31441c2257b87c2e795c5228ae80d2d8 \
+    --hash=sha256:f6cde21a9c68cf756af02035f72d5a723bf607e862e7be33ece505abf4a3bad9
 typer==0.7.0 ; python_version >= "3.8" and python_version < "3.11" \
     --hash=sha256:b5e704f4e48ec263de1c0b3a2387cd405a13767d2f907f44c1a08cbad96f606d \
     --hash=sha256:ff797846578a9f2a201b53442aedeb543319466870fbe1c701eab66dd7681165

--- a/src/sk_transformers/string_transformer.py
+++ b/src/sk_transformers/string_transformer.py
@@ -4,7 +4,7 @@ import itertools
 import re
 import unicodedata
 from difflib import SequenceMatcher
-from typing import List, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 import pandas as pd
 import phonenumbers
@@ -354,7 +354,7 @@ class StringSlicerTransformer(BaseTransformer):
     ```
 
     Args:
-        features (List[Tuple[str, Union[Tuple[int], Tuple[int, int], Tuple[int, int, int]]]]): The arguments to the `slice` function, for each feature.
+        features (List[Tuple[str, Union[Tuple[int], Tuple[int, int], Tuple[int, int, int]], Optional[str]]]): The arguments to the `slice` function, for each feature.
     """
 
     def __init__(
@@ -363,6 +363,7 @@ class StringSlicerTransformer(BaseTransformer):
             Tuple[
                 str,
                 Union[Tuple[int], Tuple[int, int], Tuple[int, int, int]],
+                Optional[str],
             ]
         ],
     ) -> None:
@@ -380,8 +381,11 @@ class StringSlicerTransformer(BaseTransformer):
         """
         X = check_ready_to_transform(self, X, [feature[0] for feature in self.features])
 
-        for feature, slice_args in self.features:
-            X[feature + "_slice"] = [x[slice(*slice_args)] for x in X[feature]]
+        for slice_tuple in self.features:
+            column = slice_tuple[0]
+            slice_args = slice_tuple[1]
+            slice_column = slice_tuple[2] if len(slice_tuple) == 3 else column
+            X[slice_column] = [x[slice(*slice_args)] for x in X[column]]
 
         return X
 

--- a/tests/test_transformer/test_string_transformer.py
+++ b/tests/test_transformer/test_string_transformer.py
@@ -177,28 +177,56 @@ def test_string_splitter_transformer_in_pipeline(X_strings):
     pipeline = make_pipeline(
         StringSplitterTransformer(
             [
-                ("email", "@", 2),
+                ("strings_2", "_", 1),
             ]
         )
     )
     result = pipeline.fit_transform(X_strings)
     expected_part_1 = [
-        "test",
-        "test123",
-        "test_123$$",
-        "test_test",
-        "ttt",
-        "test_test_test",
+        "this",
+        "this",
+        "this is a third string",
+        "this",
+        " ",
+        "!@#$%^&*()",
     ]
     expected_part_2 = [
-        "test1.com",
-        "test2.com",
-        "test3.com",
-        "test4.com",
-        "test5.com",
+        "is_not_a_string",
+        "is_another_string",
         None,
+        "is_a_fifth_string",
+        None,
+        "+",
     ]
 
-    assert np.array_equal(result["email_part_1"], expected_part_1)
-    assert np.array_equal(result["email_part_2"], expected_part_2)
+    assert np.array_equal(result["strings_2_part_1"], expected_part_1)
+    assert np.array_equal(result["strings_2_part_2"], expected_part_2)
+    assert pipeline.steps[0][0] == "stringsplittertransformer"
+
+
+def test_string_splitter_transformer_no_maxsplits_in_pipeline(X_strings):
+    pipeline = make_pipeline(
+        StringSplitterTransformer(
+            [
+                ("strings_2", "_"),
+            ]
+        )
+    )
+    result = pipeline.fit_transform(X_strings)
+
+    assert "strings_2_part_5" in result.columns
+    assert pipeline.steps[0][0] == "stringsplittertransformer"
+
+
+def test_string_splitter_transformer_zero_maxsplits_in_pipeline(X_strings):
+    pipeline = make_pipeline(
+        StringSplitterTransformer(
+            [
+                ("strings_2", "_", 0),
+            ]
+        )
+    )
+    result = pipeline.fit_transform(X_strings)
+
+    assert "strings_2_part_5" in result.columns
     assert pipeline.steps[0][0] == "stringsplittertransformer"

--- a/tests/test_transformer/test_string_transformer.py
+++ b/tests/test_transformer/test_string_transformer.py
@@ -128,7 +128,7 @@ def test_string_slicer_transformer_in_pipeline(X_strings):
 
     expected = pd.DataFrame(
         {
-            "email_slice": [
+            "email": [
                 "test@",
                 "test1",
                 "test_",
@@ -136,7 +136,7 @@ def test_string_slicer_transformer_in_pipeline(X_strings):
                 "ttt@t",
                 "test_",
             ],
-            "strings_1_slice": [
+            "strings_1": [
                 "a_string",
                 "another_",
                 "a_third_",
@@ -144,7 +144,7 @@ def test_string_slicer_transformer_in_pipeline(X_strings):
                 "a_fifth_",
                 "a_sixth_",
             ],
-            "strings_2_slice": [
+            "strings_2": [
                 "i_o__",
                 "i_nte",
                 "i  hr",
@@ -156,9 +156,21 @@ def test_string_slicer_transformer_in_pipeline(X_strings):
     )
 
     assert pipeline.steps[0][0] == "stringslicertransformer"
-    assert result[["email_slice", "strings_1_slice", "strings_2_slice"]].equals(
-        expected
+    assert result[["email", "strings_1", "strings_2"]].equals(expected)
+
+
+def test_string_slicer_transformer_new_column_name_in_pipeline(X_strings):
+    pipeline = make_pipeline(
+        StringSlicerTransformer(
+            [
+                ("email", (5,), "new_email_slice"),
+            ]
+        )
     )
+    result = pipeline.fit_transform(X_strings)
+
+    assert "new_email_slice" in result.columns
+    assert pipeline.steps[0][0] == "stringslicertransformer"
 
 
 def test_string_splitter_transformer_in_pipeline(X_strings):


### PR DESCRIPTION
This PR

- adds the ability to provide custom column names for newly-created columns in `StringSlicerTransformer`.
- makes `StringSplitterTransformer` create maximum number of splits if the number of splits is not provided or is 0 or -1.